### PR TITLE
Add script to push changes to ECR

### DIFF
--- a/bin/push-changes.sh
+++ b/bin/push-changes.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+while [ $# -gt 0 ]; do
+  case $1 in
+    --only-client)
+      only_client=true;;
+    --only-server)
+      only_server=true;;
+    esac
+    shift
+done
+
+if [[ $only_client = true && $only_server = true ]]; then
+  echo 'If you want both server and client, do not pass any of those 2 flags'
+  echo '\t--only-server and --only-client are mutually exclusive'
+  exit
+fi
+
+## AWS CLI
+# Login
+$(aws ecr get-login --no-include-email --region us-east-2)
+
+## Client
+if [ -z $only_server ]; then
+  # Build client
+  docker build -t dockerifi-client ./client
+
+  # Tag client
+  docker tag dockerifi-client:latest 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-client:latest
+
+  # Push client
+  docker push 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-client:latest
+fi
+
+## Server
+if [ -z $only_client ]; then
+  # Build server
+  docker build -t dockerifi-server ./server
+
+  # Tag server
+  docker tag dockerifi-server:latest 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-server:latest
+
+  # Push server
+  docker push 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-server:latest
+fi

--- a/bin/start-dev.sh
+++ b/bin/start-dev.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# TODO: Cleanup docker intermediate images
 
 docker-compose down
 docker-compose up --build --remove-orphans


### PR DESCRIPTION
Added the script to push changes to ECR.

By default, it will rebuild both the client and the server.
We can add the `--only-client` or `--only-server` flags, to push only the one we want.
If a user tries to use both flags at once, a user-friendly message will be displayed, and the script will exit.