### PR TITLE
Allow explicit tag on ECR repository

### DIFF
--- a/bin/push-changes.sh
+++ b/bin/push-changes.sh
@@ -6,9 +6,23 @@ while [ $# -gt 0 ]; do
       only_client=true;;
     --only-server)
       only_server=true;;
+    --server-tag)
+      server_tag=$2
+      shift;;
+    --client-tag)
+      client_tag=$2
+      shift;;
     esac
     shift
 done
+
+if [ -z $server_tag ]; then
+  server_tag=latest
+fi
+
+if [ -z $client_tag ]; then
+  client_tag=latest
+fi
 
 if [[ $only_client = true && $only_server = true ]]; then
   echo 'If you want both server and client, do not pass any of those 2 flags'
@@ -23,23 +37,23 @@ $(aws ecr get-login --no-include-email --region us-east-2)
 ## Client
 if [ -z $only_server ]; then
   # Build client
-  docker build -t dockerifi-client ./client
+  docker build -t dockerifi-client:$client_tag ./client/
 
   # Tag client
-  docker tag dockerifi-client:latest 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-client:latest
+  docker tag dockerifi-client:$client_tag 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-client:$client_tag
 
   # Push client
-  docker push 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-client:latest
+  docker push 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-client:$client_tag
 fi
 
 ## Server
 if [ -z $only_client ]; then
   # Build server
-  docker build -t dockerifi-server ./server
+  docker build -t dockerifi-server:$server_tag ./server/
 
   # Tag server
-  docker tag dockerifi-server:latest 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-server:latest
+  docker tag dockerifi-server:$server_tag 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-server:$server_tag
 
   # Push server
-  docker push 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-server:latest
+  docker push 303881595170.dkr.ecr.us-east-2.amazonaws.com/dockerifi-server:$server_tag
 fi


### PR DESCRIPTION
Now we should be able to tag the image. If we won't do it, it will default to `latest`
In order to add a tag, we have to use the `--server-tag X` and `--client-tag Y`
E.g.
```
./bin/push-changes.sh --server-tag 2.2 --only-server
./bin/push-changes.sh --client-tag 2.2 --only-client
./bin/push-changes.sh --server-tag 1.4
./bin/push-changes.sh --client-tag 2.1 --server-tag 3.0
./bin/push-changes.sh --only-client
```